### PR TITLE
Unmarshal empty strings as strings instead of null

### DIFF
--- a/serialize/unserialize.go
+++ b/serialize/unserialize.go
@@ -132,6 +132,8 @@ func unMarshalString(reader *bytes.Reader, isFinal bool) (interface{}, error) {
 				val = string(buf)
 			}
 		}
+	} else {
+		val = ""
 	}
 
 	err = expect(reader, '"')


### PR DESCRIPTION
Empty string values ('s:0:""') within an array are being unserialized to null, this change will unserialize them to "" instead.